### PR TITLE
Fix UNITY_LTS definition

### DIFF
--- a/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
+++ b/Src/Newtonsoft.Json.Tests/Newtonsoft.Json.Tests.csproj
@@ -45,6 +45,28 @@
         <ProjectReference Include="..\Newtonsoft.Json\Newtonsoft.Json.csproj"/>
     </ItemGroup>
 
+    <!-- Unity support -->
+    <!-- Important: PropertyGroup order does matter. Be sure to set UnityConstants before DefineConstants use it. -->
+    <PropertyGroup Condition="'$(Configuration)'=='UnityEditor'">
+        <!-- Only used in Editor -->
+        <!-- Since this is originally a multi target framework, we have to always use TargetFrameworks tag.
+          Using TargetFramework (without a 's') when targetting a single framework will cause unexpected behaviour,
+          and fail to retrieve DefineConstants specific to a given target framework.
+          Append a ';' to avoid the warning "Only one target framework moniker specified" -->
+        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+        <Optimize>true</Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'=='UnityAOT'">
+        <!-- Unity AOT (IL2CPP) build -->
+        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
+        <UnityConstants>UNITY_LTS</UnityConstants>
+        <Optimize>true</Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'!='UnityAOT' AND '$(Configuration)'!='UnityEditor'">
+        <TargetFrameworks Condition="'$(TestFrameworks)'==''">net46;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks Condition="'$(TestFrameworks)'!=''">$(TestFrameworks);</TargetFrameworks>
+    </PropertyGroup>
+
     <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
         <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)"/>
         <PackageReference Include="FSharp.Core" Version="$(FSharpCorePackageVersion)"/>
@@ -63,9 +85,9 @@
     <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
         <AssemblyTitle>Json.NET Tests .NET 6.0</AssemblyTitle>
         <ReferringTargetFrameworkForProjectReferences>net6.0</ReferringTargetFrameworkForProjectReferences>
-        <DefineConstants>NET6_0;DNXCORE50;PORTABLE;HAVE_BENCHMARKS;HAVE_REGEX_TIMEOUTS;$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NET6_0;DNXCORE50;PORTABLE;HAVE_BENCHMARKS;HAVE_REGEX_TIMEOUTS;$(UnityConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
-    
+
     <ItemGroup Condition="'$(TargetFramework)'=='net46'">
         <PackageReference Include="NUnit" Version="$(NunitPackageVersion)"/>
         <PackageReference Include="NUnit3TestAdapter" Version="$(Nunit3TestAdapterPackageVersion)"/>
@@ -87,7 +109,7 @@
     <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
         <AssemblyTitle>Json.NET Tests</AssemblyTitle>
         <ReferringTargetFrameworkForProjectReferences>.NETFramework,Version=v4.6</ReferringTargetFrameworkForProjectReferences>
-        <DefineConstants>NET46;HAVE_BENCHMARKS;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NET46;HAVE_BENCHMARKS;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net40'">
@@ -104,7 +126,7 @@
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
         <AssemblyTitle>Json.NET Tests .NET 4.0</AssemblyTitle>
-        <DefineConstants>NET40;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NET40;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net35'">
@@ -119,7 +141,7 @@
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetFramework)'=='net35'">
         <AssemblyTitle>Json.NET Tests .NET 3.5</AssemblyTitle>
-        <DefineConstants>NET35;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NET35;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='net20'">
@@ -129,7 +151,7 @@
     </ItemGroup>
     <PropertyGroup Condition="'$(TargetFramework)'=='net20'">
         <AssemblyTitle>Json.NET Tests .NET 2.0</AssemblyTitle>
-        <DefineConstants>NET20;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NET20;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
@@ -150,7 +172,7 @@
     <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
         <AssemblyTitle>Json.NET Tests .NET Standard 2.0</AssemblyTitle>
         <ReferringTargetFrameworkForProjectReferences>.NETStandard,Version=v2.0</ReferringTargetFrameworkForProjectReferences>
-        <DefineConstants>NETSTANDARD2_0;NETSTANDARD1_3;DNXCORE50;PORTABLE;HAVE_BENCHMARKS;HAVE_REGEX_TIMEOUTS;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
+        <DefineConstants>NETSTANDARD2_0;NETSTANDARD1_3;DNXCORE50;PORTABLE;HAVE_BENCHMARKS;HAVE_REGEX_TIMEOUTS;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
@@ -171,28 +193,6 @@
     <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
         <AssemblyTitle>Json.NET Tests .NET Standard 1.0</AssemblyTitle>
         <ReferringTargetFrameworkForProjectReferences>.NETStandard,Version=v1.0</ReferringTargetFrameworkForProjectReferences>
-        <DefineConstants>NETSTANDARD1_0;DNXCORE50;PORTABLE;HAVE_REGEX_TIMEOUTS;$(DefineConstants);$(AdditionalConstants)</DefineConstants>
-    </PropertyGroup>
-
-    <!-- Unity support -->
-    <PropertyGroup Condition="'$(Configuration)'=='UnityEditor'">
-        <!-- Only used in Editor -->
-        <!-- Since this is originally a multi target framework, we have to always use TargetFrameworks tag.
-          Using TargetFramework (without a 's') when targetting a single framework will cause unexpected behaviour,
-          and fail to retrieve DefineConstants specific to a given target framework.
-          Append a ';' to avoid the warning "Only one target framework moniker specified" -->
-        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
-        <Optimize>true</Optimize>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='UnityAOT'">
-        <!-- Unity AOT (IL2CPP) build -->
-        <TargetFrameworks>netcoreapp3.1;</TargetFrameworks>
-        <UnityConstants>UNITY_LTS</UnityConstants>
-        <Optimize>true</Optimize>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)'!='UnityAOT' AND '$(Configuration)'!='UnityEditor'">
-        <TargetFrameworks Condition="'$(TestFrameworks)'==''">net46;netcoreapp2.1</TargetFrameworks>
-        <TargetFrameworks Condition="'$(TestFrameworks)'!=''">$(TestFrameworks);</TargetFrameworks>
+        <DefineConstants>NETSTANDARD1_0;DNXCORE50;PORTABLE;HAVE_REGEX_TIMEOUTS;$(UnityConstants);$(DefineConstants);$(AdditionalConstants)</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
+++ b/Src/Newtonsoft.Json/Newtonsoft.Json.csproj
@@ -50,6 +50,45 @@
         <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersPackageVersion)" PrivateAssets="All"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPackageVersion)" PrivateAssets="All"/>
     </ItemGroup>
+
+    <!-- Unity support -->
+    <!-- Important: PropertyGroup order does matter. Be sure to set UnityConstants before DefineConstants use it. -->
+    <PropertyGroup>
+        <!-- force legacy .pdb format for Mono's pdb2mdb -->
+        <DebugType>Full</DebugType>
+        <!-- including PDB files in NuGet for source link because symbolsource.org does not support portable PDBs -->
+        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+        <!-- Breaks build for some reason.-->
+        <!--        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>-->
+    </PropertyGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Resources\link.xml">
+            <LogicalName>Newtonsoft.Json.xml</LogicalName>
+        </EmbeddedResource>
+        <None Include="$(PackageIconFullPath)" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+    <PropertyGroup Condition="'$(Configuration)'=='UnityEditor'">
+        <!-- Only used in Editor -->
+        <!-- Since this is originally a multi target framework, we have to always use TargetFrameworks tag.
+          Using TargetFramework (without a 's') when targetting a single framework will cause unexpected behaviour,
+          and fail to retrieve DefineConstants specific to a given target framework.
+          Append a ';' to avoid the warning "Only one target framework moniker specified" -->
+        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+        <AssemblyTitle>Json.NET for Unity Editor (NOT FOR PRODUCTION)</AssemblyTitle>
+        <Optimize>true</Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'=='UnityAOT'">
+        <!-- Unity AOT (IL2CPP) build -->
+        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
+        <AssemblyTitle>Json.NET for Unity AOT (IL2CPP)</AssemblyTitle>
+        <UnityConstants>UNITY_LTS</UnityConstants>
+        <Optimize>true</Optimize>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'!='UnityAOT' AND '$(Configuration)'!='UnityEditor'">
+        <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">net46;netstandard1.0;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks);</TargetFrameworks>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
         <AssemblyTitle>Json.NET .NET 6.0</AssemblyTitle>
         <DefineConstants>HAVE_ADO_NET;HAVE_APP_DOMAIN;HAVE_ASYNC;HAVE_ASYNC_DISPOSABLE;HAVE_BIG_INTEGER;HAVE_BINARY_FORMATTER;HAVE_BINARY_SERIALIZATION;HAVE_BINARY_EXCEPTION_SERIALIZATION;HAVE_CHAR_TO_LOWER_WITH_CULTURE;HAVE_CHAR_TO_STRING_WITH_CULTURE;HAVE_COM_ATTRIBUTES;HAVE_COMPONENT_MODEL;HAVE_CONCURRENT_COLLECTIONS;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DB_NULL_TYPE_CODE;HAVE_DYNAMIC;HAVE_EMPTY_TYPES;HAVE_ENTITY_FRAMEWORK;HAVE_EXPRESSIONS;HAVE_FAST_REVERSE;HAVE_FSHARP_TYPES;HAVE_FULL_REFLECTION;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_ICLONEABLE;HAVE_ICONVERTIBLE;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_MEMORY_BARRIER;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_EMIT;HAVE_REGEX_TIMEOUTS;HAVE_SECURITY_SAFE_CRITICAL_ATTRIBUTE;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STREAM_READER_WRITER_CLOSE;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TRACE_WRITER;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_XML_DOCUMENT;HAVE_XML_DOCUMENT_TYPE;HAVE_CONCURRENT_DICTIONARY;HAVE_INDEXOF_STRING_COMPARISON;HAVE_REPLACE_STRING_COMPARISON;HAVE_REPLACE_STRING_COMPARISON;HAVE_GETHASHCODE_STRING_COMPARISON;HAVE_NULLABLE_ATTRIBUTES;HAVE_DYNAMIC_CODE_COMPILED;HAS_ARRAY_EMPTY;HAVE_DATE_ONLY;$(UnityConstants);$(AdditionalConstants)</DefineConstants>
@@ -90,43 +129,5 @@
     <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <AssemblyTitle>Json.NET .NET Standard 2.0</AssemblyTitle>
         <DefineConstants>NETSTANDARD2_0;HAVE_ADO_NET;HAVE_APP_DOMAIN;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_FORMATTER;HAVE_BINARY_SERIALIZATION;HAVE_BINARY_EXCEPTION_SERIALIZATION;HAVE_CHAR_TO_LOWER_WITH_CULTURE;HAVE_CHAR_TO_STRING_WITH_CULTURE;HAVE_COM_ATTRIBUTES;HAVE_COMPONENT_MODEL;HAVE_CONCURRENT_COLLECTIONS;HAVE_COVARIANT_GENERICS;HAVE_DATA_CONTRACTS;HAVE_DATE_TIME_OFFSET;HAVE_DB_NULL_TYPE_CODE;HAVE_DYNAMIC;HAVE_EMPTY_TYPES;HAVE_ENTITY_FRAMEWORK;HAVE_EXPRESSIONS;HAVE_FAST_REVERSE;HAVE_FSHARP_TYPES;HAVE_FULL_REFLECTION;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_ICLONEABLE;HAVE_ICONVERTIBLE;HAVE_IGNORE_DATA_MEMBER_ATTRIBUTE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_MEMORY_BARRIER;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_SECURITY_SAFE_CRITICAL_ATTRIBUTE;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STREAM_READER_WRITER_CLOSE;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TRACE_WRITER;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XLINQ;HAVE_XML_DOCUMENT;HAVE_XML_DOCUMENT_TYPE;HAVE_CONCURRENT_DICTIONARY;HAVE_REGEX_TIMEOUTS;$(UnityConstants);$(AdditionalConstants)</DefineConstants>
-    </PropertyGroup>
-
-    <!-- Unity support -->
-    <PropertyGroup>
-        <!-- force legacy .pdb format for Mono's pdb2mdb -->
-        <DebugType>Full</DebugType>
-        <!-- including PDB files in NuGet for source link because symbolsource.org does not support portable PDBs -->
-        <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-        <!-- Breaks build for some reason.-->
-        <!--        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>-->
-    </PropertyGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="Resources\link.xml">
-            <LogicalName>Newtonsoft.Json.xml</LogicalName>
-        </EmbeddedResource>
-        <None Include="$(PackageIconFullPath)" Pack="true" PackagePath="\"/>
-    </ItemGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='UnityEditor'">
-        <!-- Only used in Editor -->
-        <!-- Since this is originally a multi target framework, we have to always use TargetFrameworks tag.
-          Using TargetFramework (without a 's') when targetting a single framework will cause unexpected behaviour,
-          and fail to retrieve DefineConstants specific to a given target framework.
-          Append a ';' to avoid the warning "Only one target framework moniker specified" -->
-        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-        <AssemblyTitle>Json.NET for Unity Editor (NOT FOR PRODUCTION)</AssemblyTitle>
-        <Optimize>true</Optimize>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'=='UnityAOT'">
-        <!-- Unity AOT (IL2CPP) build -->
-        <TargetFrameworks>netstandard2.0;</TargetFrameworks>
-        <AssemblyTitle>Json.NET for Unity AOT (IL2CPP)</AssemblyTitle>
-        <UnityConstants>UNITY_LTS</UnityConstants>
-        <Optimize>true</Optimize>
-    </PropertyGroup>
-
-    <PropertyGroup Condition="'$(Configuration)'!='UnityAOT' AND '$(Configuration)'!='UnityEditor'">
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'==''">net46;netstandard1.0;netstandard2.0</TargetFrameworks>
-        <TargetFrameworks Condition="'$(LibraryFrameworks)'!=''">$(LibraryFrameworks);</TargetFrameworks>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
`PropertyGroup` order matters so we make sure we set `UnityConstants` before it is used in `DefineConstants`.